### PR TITLE
Added additional target framework of .Net Framework 4.5.

### DIFF
--- a/src/T4Immutable-netstd2/T4Immutable-netstd2.csproj
+++ b/src/T4Immutable-netstd2/T4Immutable-netstd2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <AssemblyName>T4Immutable</AssemblyName>
     <RootNamespace>T4Immutable</RootNamespace>
     <PackageId>T4Immutable</PackageId>
@@ -15,7 +15,8 @@
     <PackageProjectUrl>https://github.com/xaviergonz/T4Immutable</PackageProjectUrl>
     <PackageTags>t4 immutable codegen</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -30,6 +31,15 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="echo Copying Attributes.cs to content folder&#xD;&#xA;cd $(ProjectDir)&#xD;&#xA;copy Attributes.cs ..\content\T4Immutable\Attributes.cs_&#xD;&#xA;cd $(TargetDir)" />
   </Target>
+
+  <ItemGroup>
+    <Content Include="..\readme.txt">
+      <PackagePath>readme.txt</PackagePath>
+    </Content>
+    <Content Include="..\content\**\*">
+      <PackagePath>contentFiles\any\any;content</PackagePath>
+    </Content>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />


### PR DESCRIPTION
Hi @xaviergonz,

Here is a simple PR with a couple of changes that I made.  I wanted to use your project in a Unity3D application which currently requires the full .Net Framework (experimental support for 4.5).  So I've added the target to the project definition.

I also changed the configuration so that the Nuget package should be correctly built from within Visual Studio 2017 (or presumably MSBuild on the command line).  If you have access to this version of Visual Studio, you may consider removing the packaging script and nuspec file, as they are no longer required.

Let me know what you think.

* Added additional target framework of .Net Framework 4.5.
* Added configuration to allow VS2017 to build Nuget package from the .csproj definition.